### PR TITLE
fix issue in specs causing wisper/rspec/matchers to be loaded from the wisper gem

### DIFF
--- a/spec/wisper/rspec/matchers_spec.rb
+++ b/spec/wisper/rspec/matchers_spec.rb
@@ -1,4 +1,4 @@
-require 'wisper/rspec/matchers'
+require File.expand_path('../../../../lib/wisper/rspec/matchers', __FILE__)
 
 RSpec::configure do |config|
   config.include(Wisper::RSpec::BroadcastMatcher)


### PR DESCRIPTION
Addresses https://github.com/krisleech/wisper-rspec/issues/3#issuecomment-69545607.