### PR TITLE
clearer failure message

### DIFF
--- a/lib/wisper/rspec/matchers.rb
+++ b/lib/wisper/rspec/matchers.rb
@@ -49,14 +49,8 @@ module Wisper
 
         def failure_message
           msg = "expected publisher to broadcast #{@event} event"
-          if @args.size == 0
-            if @event_recorder.broadcast_events.any?
-              msg += " (not included in #{@event_recorder.broadcast_events.map(&:first).join(', ')})"
-            else
-              msg += " (no events broadcast)"
-            end
-          end
           msg += " with args: #{@args.inspect}" if @args.size > 0
+          msg << broadcast_events_list
           msg
         end
 
@@ -64,6 +58,14 @@ module Wisper
           msg = "expected publisher not to broadcast #{@event} event"
           msg += " with args: #{@args.inspect}" if @args.size > 0
           msg
+        end
+
+        def broadcast_events_list
+          if @event_recorder.broadcast_events.any?
+            " (actual events broadcast: #{@event_recorder.broadcast_events.map(&:first).join(', ')})"
+          else
+            " (no events broadcast)"
+          end
         end
       end
 

--- a/lib/wisper/rspec/matchers.rb
+++ b/lib/wisper/rspec/matchers.rb
@@ -62,11 +62,19 @@ module Wisper
 
         def broadcast_events_list
           if @event_recorder.broadcast_events.any?
-            " (actual events broadcast: #{@event_recorder.broadcast_events.map(&:first).join(', ')})"
+            " (actual events broadcast: #{event_names.join(', ')})"
           else
             " (no events broadcast)"
           end
         end
+        private :broadcast_events_list
+
+        def event_names
+          @event_recorder.broadcast_events.map do |event|
+            event.size == 1 ? event[0] : "#{event[0]}(#{event[1..-1].join(", ")})"
+          end
+        end
+        private :event_names
       end
 
       def broadcast(event, *args)

--- a/spec/wisper/rspec/unit/broadcast_matcher_spec.rb
+++ b/spec/wisper/rspec/unit/broadcast_matcher_spec.rb
@@ -63,7 +63,7 @@ describe Wisper::RSpec::BroadcastMatcher::Matcher do
       before { matcher.matches?(block) }
 
       it 'has descriptive failure message' do
-        expect(matcher.failure_message).to eq "expected publisher to broadcast it_happened event (not included in event1, event2)"
+        expect(matcher.failure_message).to eq "expected publisher to broadcast it_happened event (actual events broadcast: event1, event2)"
       end
     end
   end

--- a/spec/wisper/rspec/unit/broadcast_matcher_spec.rb
+++ b/spec/wisper/rspec/unit/broadcast_matcher_spec.rb
@@ -49,7 +49,7 @@ describe Wisper::RSpec::BroadcastMatcher::Matcher do
     let(:block) do
       Proc.new do
         broadcaster.broadcast('event1')
-        broadcaster.broadcast('event2')
+        broadcaster.send(:broadcast, 'event2', 12345, :foo)
       end
     end
 
@@ -63,7 +63,9 @@ describe Wisper::RSpec::BroadcastMatcher::Matcher do
       before { matcher.matches?(block) }
 
       it 'has descriptive failure message' do
-        expect(matcher.failure_message).to eq "expected publisher to broadcast it_happened event (actual events broadcast: event1, event2)"
+        message = "expected publisher to broadcast it_happened event "\
+          "(actual events broadcast: event1, event2(12345, foo))"
+        expect(matcher.failure_message).to eq(message)
       end
     end
   end


### PR DESCRIPTION
It looks like the message I wanted was already there, but only when `@args.size == 0`. I'm not sure why, so I basically just removed that check. I don't think the specs have any cases where there are args, so the only change I made to the specs was just a small change in the verbiage.