### PR TITLE
Make broadcast matchers composable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,21 @@ With event arguments, it matches only if the event is broadcast with those argum
 expect { publisher.execute }.to broadcast(:event, hash_including(a: 2))
 ```
 
-Rspec values matcher can be used to match arguments. This assertion matches `broadcast(:another_event, a: 2, b: 1)` but not `broadcast(:another_event, a: 3)` 
+Rspec values matcher can be used to match arguments. This assertion matches `broadcast(:another_event, a: 2, b: 1)` but not `broadcast(:another_event, a: 3)`
+ 
+Matchers can be composed using [compound rspec matchers](http://www.rubydoc.info/gems/rspec-expectations/RSpec/Matchers/Composable):
+
+```ruby
+expect {
+  publisher.execute(123)
+  publisher.execute(234)
+}.to broadcast(:event, 123).and broadcast(:event, 234)
+
+expect {
+  publisher.execute(123)
+  publisher.execute(234)
+}.to broadcast(:event, 123).or broadcast(:event, 234)
+```
 
 ### Using message expections
 

--- a/lib/wisper/rspec/matchers.rb
+++ b/lib/wisper/rspec/matchers.rb
@@ -30,6 +30,8 @@ module Wisper
 
     module BroadcastMatcher
       class Matcher
+        include ::RSpec::Matchers::Composable
+
         def initialize(event, *args)
           @event = event
           @args = args

--- a/spec/wisper/rspec/matchers_spec.rb
+++ b/spec/wisper/rspec/matchers_spec.rb
@@ -34,6 +34,21 @@ describe 'broadcast matcher' do
     end
   end
 
+  context 'with compound assertions' do
+    it 'passes when both values are expected' do
+      expect {
+        publisher.send(:broadcast, :fizzbuzz, 12345)
+        publisher.send(:broadcast, :fizzbuzz, 54321)
+      }.to broadcast(:fizzbuzz, 12345).and broadcast(:fizzbuzz, 54321)
+    end
+
+    it 'passes when either value is expected' do
+      expect {
+        publisher.send(:broadcast, :fizzbuzz, 54321)
+      }.to broadcast(:fizzbuzz, 12345).or broadcast(:fizzbuzz, 54321)
+    end
+  end
+
   it 'passes with not_to when publisher does not broadcast inside block' do
     expect { publisher }.not_to broadcast(:foobar)
   end


### PR DESCRIPTION
This change enables creating compound assertions:

    expect {
        publisher.send(:broadcast, :fizzbuzz, 12345)
        publisher.send(:broadcast, :fizzbuzz, 54321)
      }.to broadcast(:fizzbuzz, 12345).and broadcast(:fizzbuzz, 54321)