### PR TITLE
aliases publish to the broadcast custom RSpec matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ expect { publisher.execute }.to broadcast(:event, hash_including(a: 2))
 ```
 
 Rspec values matcher can be used to match arguments. This assertion matches `broadcast(:another_event, a: 2, b: 1)` but not `broadcast(:another_event, a: 3)`
- 
+
 Matchers can be composed using [compound rspec matchers](http://www.rubydoc.info/gems/rspec-expectations/RSpec/Matchers/Composable):
 
 ```ruby
@@ -59,6 +59,8 @@ expect {
   publisher.execute(234)
 }.to broadcast(:event, 123).or broadcast(:event, 234)
 ```
+
+Note that the `broadcast` method is aliased as `publish`, similar to the *Wisper* library itself.
 
 ### Using message expections
 

--- a/lib/wisper/rspec/matchers.rb
+++ b/lib/wisper/rspec/matchers.rb
@@ -100,6 +100,8 @@ module Wisper
       def broadcast(event, *args)
         Matcher.new(event, *args)
       end
+
+      alias_method :publish, :broadcast
     end
   end
 


### PR DESCRIPTION
@krisleech I noticed that the Wisper library has an alias from `publish` to `broadcast` for the `Wisper::Publisher` class ([see here](https://github.com/krisleech/wisper/blob/master/lib/wisper/publisher.rb#L48)). However, this alias does not also exist for your custom rspec matchers in this library. It can be confusing if you write a spec that calls `publisher.publish`, but you are forced to check whether `broadcast` has been called instead of `publish` using RSpec [method expectations](http://www.relishapp.com/rspec/rspec-mocks/v/3-5/docs/basics/expecting-messages).

Also, a friendly inquiry on the status of this library as well as wisper. I have been using the library recently and it is working out great for my Ruby event messaging needs. Is there a stable release planned soon?
