### PR TITLE
Fix missing description error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Unreleased
 
+* Fixed the error of the missing matcher description (https://github.com/krisleech/wisper-rspec/pull/32)
+
 1.1.0 (15/May/2018)
 
 Authors: Nikolai (nikolai-b), David Kennedy (TheTeaNerd)

--- a/lib/wisper/rspec/matchers.rb
+++ b/lib/wisper/rspec/matchers.rb
@@ -55,6 +55,12 @@ module Wisper
           @event_recorder.broadcast?(@event, *@args)
         end
 
+        def description
+          msg = "broadcast #{@event} event"
+          msg += " with args: #{@args.inspect}" if @args.size > 0
+          msg
+        end
+
         def failure_message
           msg = "expected publisher to broadcast #{@event} event"
           msg += " with args: #{@args.inspect}" if @args.size > 0

--- a/spec/wisper/rspec/unit/broadcast_matcher_spec.rb
+++ b/spec/wisper/rspec/unit/broadcast_matcher_spec.rb
@@ -13,6 +13,30 @@ describe Wisper::RSpec::BroadcastMatcher::Matcher do
     end.new
   end
 
+  describe '#description' do
+    it 'has descriptive message' do
+      expect(matcher.description).to eq "broadcast #{event_name} event"
+    end
+  end
+
+  describe '#failure_message_when_negated' do
+    subject(:message) { matcher.failure_message_when_negated }
+
+    context 'when with args' do
+      let(:matcher) { described_class.new(event_name, 1) }
+
+      it 'has descriptive message' do
+        expect(message).to eq "expected publisher not to broadcast #{event_name} event with args: [1]"
+      end
+    end
+
+    context 'when without args' do
+      it 'has descriptive message' do
+        expect(message).to eq "expected publisher not to broadcast #{event_name} event"
+      end
+    end
+  end
+
   context 'matching event broadcast' do
     let(:block) do
       Proc.new do


### PR DESCRIPTION
When test written without description and RSpec output formatter is
"doc" rspec-expectations tries to generate output message from
matcher's description which BroadcastMatcher doesn't have.

Problem can be reproduced by simple script 
```ruby
# test.rb

require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'rspec'
  gem 'wisper'
  gem 'wisper-rspec'
end

require 'wisper/rspec/matchers'

RSpec.configure do |config|
  config.default_formatter = 'doc'
end

RSpec.describe 'missing matcher description' do
  include Wisper::RSpec::BroadcastMatcher

  let(:publisher_class) { Class.new { include Wisper::Publisher } }
  let(:publisher) { publisher_class.new }

  specify do
    expect { publisher.send(:broadcast, :foo) }.to broadcast(:foo)
  end
end
```
```
$ rspec test.rb

missing matcher description
  should When you call a matcher in an example without a String, like this:

specify { expect(object).to matcher }

or this:

it { is_expected.to matcher }

RSpec expects the matcher to have a #description method. You should either
add a String to the example this matcher is being used in, or give it a
description method. Then you won't have to suffer this lengthy warning again.

Finished in 0.00497 seconds (files took 0.29444 seconds to load)
1 example, 0 failures
```