### PR TITLE
Adds not_publish matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 
 * Fixed the error of the missing matcher description (https://github.com/krisleech/wisper-rspec/pull/32)
+* Add not_publish matcher (https://github.com/krisleech/wisper-rspec/pull/35)
 
 1.1.0 (15/May/2018)
 

--- a/lib/wisper/rspec/matchers.rb
+++ b/lib/wisper/rspec/matchers.rb
@@ -128,3 +128,4 @@ module Wisper
 end
 
 ::RSpec::Matchers.define_negated_matcher :not_broadcast, :broadcast
+::RSpec::Matchers.define_negated_matcher :not_publish, :publish

--- a/spec/wisper/rspec/matchers_spec.rb
+++ b/spec/wisper/rspec/matchers_spec.rb
@@ -13,6 +13,15 @@ describe 'not_broadcast matcher' do
   end
 end
 
+describe 'not_publish matcher' do
+  let(:publisher_class) { Class.new { include Wisper::Publisher } }
+  let(:publisher)       { publisher_class.new }
+
+  it 'can be chained with publish' do
+    expect { publisher.send(:publish, :foobar) }.to not_publish(:barfoo).and publish(:foobar)
+  end
+end
+
 describe 'broadcast matcher' do
   let(:publisher_class) { Class.new { include Wisper::Publisher } }
   let(:publisher)       { publisher_class.new }


### PR DESCRIPTION
For those who's business nomenclature more closely matches with "publish" rather than "broadcast", having a `not_publish` matcher makes the specs easier to read.

Thanks @nikolai-b for #30 