### PR TITLE
Singleton Matcher

### DIFF
--- a/lib/wisper/rspec/matchers.rb
+++ b/lib/wisper/rspec/matchers.rb
@@ -63,7 +63,7 @@ module Wisper
         end
 
         def failure_message
-          msg = "expected publisher to broadcast #{@event} event"
+          msg = "expected publisher to broadcast '#{@event}' event"
           msg += " with args: #{@args.inspect}" if @args.size > 0
           msg << broadcast_events_list
           msg
@@ -93,7 +93,7 @@ module Wisper
 
         def broadcast_events_list
           if @event_recorder.broadcast_events.any?
-            " (actual events broadcast: #{event_names.join(', ')})"
+            "\nactual events broadcast:\n\n#{event_names.join("\n\n")}"
           else
             " (no events broadcast)"
           end

--- a/lib/wisper/rspec/matchers.rb
+++ b/lib/wisper/rspec/matchers.rb
@@ -23,10 +23,11 @@ module Wisper
         @broadcast_events << [method_name.to_s, *args]
       end
 
-      def broadcast?(event_name, *args)
+      def broadcast?(event, *args)
         expected_args = args.size > 0 ? args : [any_args]
+        event = event.to_s unless event.is_a?(SingletonMatcher)
         @broadcast_events.any? do |event_params|
-          matcher = ::RSpec::Mocks::ArgumentListMatcher.new(event_name.to_s, *expected_args)
+          matcher = ::RSpec::Mocks::ArgumentListMatcher.new(event, *expected_args)
           matcher.args_match?(*event_params)
         end
       end

--- a/spec/wisper/rspec/matchers_spec.rb
+++ b/spec/wisper/rspec/matchers_spec.rb
@@ -11,6 +11,10 @@ describe 'not_broadcast matcher' do
   it 'can be chained with broadcast' do
     expect { publisher.send(:broadcast, :foobar) }.to not_broadcast(:barfoo).and broadcast(:foobar)
   end
+  
+  it 'handles anything matchers' do
+    expect { publisher }.to not_broadcast(anything)
+  end
 end
 
 describe 'not_publish matcher' do
@@ -20,6 +24,10 @@ describe 'not_publish matcher' do
   it 'can be chained with publish' do
     expect { publisher.send(:publish, :foobar) }.to not_publish(:barfoo).and publish(:foobar)
   end
+
+  it 'handles anything matchers' do
+    expect { publisher }.to not_publish(anything)
+  end
 end
 
 describe 'broadcast matcher' do
@@ -28,6 +36,10 @@ describe 'broadcast matcher' do
 
   it 'passes when publisher broadcasts inside block' do
     expect { publisher.send(:broadcast, :foobar) }.to broadcast(:foobar)
+  end
+
+  it 'handles anything matchers' do
+    expect { publisher.send(:broadcast, :foobar) }.to broadcast(anything)
   end
 
   context 'with arguments' do

--- a/spec/wisper/rspec/unit/broadcast_matcher_spec.rb
+++ b/spec/wisper/rspec/unit/broadcast_matcher_spec.rb
@@ -64,7 +64,8 @@ describe Wisper::RSpec::BroadcastMatcher::Matcher do
       before { matcher.matches?(block) }
 
       it 'has descriptive failure message' do
-        expect(matcher.failure_message).to eq "expected publisher to broadcast #{event_name} event (no events broadcast)"
+        expect(matcher.failure_message).
+          to eq "expected publisher to broadcast '#{event_name}' event (no events broadcast)"
       end
     end
   end
@@ -87,8 +88,8 @@ describe Wisper::RSpec::BroadcastMatcher::Matcher do
       before { matcher.matches?(block) }
 
       it 'has descriptive failure message' do
-        message = "expected publisher to broadcast it_happened event "\
-          "(actual events broadcast: event1, event2(12345, foo))"
+        message = "expected publisher to broadcast 'it_happened' event"\
+          "\nactual events broadcast:\n\nevent1\n\nevent2(12345, foo)"
         expect(matcher.failure_message).to eq(message)
       end
     end


### PR DESCRIPTION
cc @krisleech 

Allows for expect blocks like:

```ruby
expect { thingy.do_and_broadcast }.to broadcast(anything)
```

Also added some newlines to the error messages because I have larger objects being broadcasted around and it was hurting my eyes. Let me know if it's not ok though and I'll remove https://github.com/krisleech/wisper-rspec/commit/01976d6b68e2e68eab7a32301a9df831d11b29f8